### PR TITLE
XE1.8.12의 보안패치로 인해 리다이렉트가 먹히지 않는 문제점개선.

### DIFF
--- a/conf/module.xml
+++ b/conf/module.xml
@@ -15,7 +15,7 @@
 		<action name="procAjaxboardAdminInsertConfig" type="controller" />
 		<action name="procAjaxboardAdminBroadcast" type="controller" />
 		<action name="procAjaxboardInsertNotificationConfig" type="controller" />
-		<action name="procAjaxboardRedirect" type="controller" />
+		<action name="procAjaxboardRedirect" method="GET|POST" type="controller" />
 
 		<action name="getAjaxboardListener" type="model" />
 		<action name="getAjaxboardDocument" type="model" />


### PR DESCRIPTION
`proc*`명령어에 &함수=값 과 같은 주소를 넣는 get형태를 취하하게 되면 보안관련 부분에서 큰 문제점이 잇어, 이를 1.8.12에서 수정했음..

때문에 ajaxboard의 해당 명령에 코드가 필요합니다..
